### PR TITLE
changed month/date/year timestamp between messages to moment in forma…

### DIFF
--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -10,7 +10,7 @@ import {
   TextProps,
 } from 'react-native'
 import dayjs from 'dayjs'
-
+import moment from 'moment'
 import Color from './Color'
 
 import { StylePropType, isSameDay } from './utils'
@@ -92,9 +92,7 @@ export default class Day<
         <View style={[styles.container, containerStyle]}>
           <View style={wrapperStyle}>
             <Text style={[styles.text, textStyle]} {...textProps}>
-              {dayjs(currentMessage.createdAt)
-                .locale(this.context.getLocale())
-                .format(dateFormat)}
+            {moment(currentMessage.createdAt, 'MMMM Do, YYYY, h:mm a').format('MMM Do, YYYY')}
             </Text>
           </View>
         </View>


### PR DESCRIPTION
To be merged with chore/upgrade-rn-to-latest on the react-native-app

problem: was getting "invalid date"in between messages after upgrading the app
fix: tweaking this line of code in the Day.js file to use moment and giving it the format seemed to fix it

